### PR TITLE
Fix clone iterable objects

### DIFF
--- a/src/Cloneable.php
+++ b/src/Cloneable.php
@@ -10,7 +10,7 @@ trait Cloneable
     {
         $clone = (new ReflectionClass(static::class))->newInstanceWithoutConstructor();
 
-        foreach ($this as $objectField => $objectValue) {
+        foreach (get_object_vars($this) as $objectField => $objectValue) {
             $objectValue = array_key_exists($objectField, $values) ? $values[$objectField] : $objectValue;
 
             $clone->$objectField = $objectValue;

--- a/tests/IterableCloneableTest.php
+++ b/tests/IterableCloneableTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Spatie\Cloneable\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Spatie\Cloneable\Cloneable;
+
+class IterableCloneableTest extends TestCase
+{
+    /** @test */
+    public function it_can_clone_iterable()
+    {
+        $collection = new Collection([1, 2, 3, 4], 1);
+        $cloned = $collection->with(mode: 2);
+
+        self::assertEquals([[1, 2, 3, 4], 2], [$cloned->items, $cloned->mode]);
+    }
+}
+
+class Collection implements \IteratorAggregate
+{
+    use Cloneable;
+
+    public function __construct(public readonly array $items, public readonly int $mode)
+    {
+    }
+
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->items);
+    }
+}


### PR DESCRIPTION
Hi! 

Currently, when trying to clone objects that implement the interface "\IteratorAggregate", an error occurs because "Spatie\Cloneable\Cloneable.php:13" iterates over the elements of the collection.

With my pull request, I propose a solution to this problem. 