### PR TITLE
Refactor GitHub Actions

### DIFF
--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -23,7 +23,6 @@ jobs:
         uses: ramsey/composer-install@v1
         with:
           composer-options: --optimize-autoloader
-          dependency-versions: ${{ matrix.stability }}
 
       - name: Run psalm
         run: ./vendor/bin/psalm --output-format=github

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -16,18 +16,14 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
+          php-version: '8.1'
           coverage: none
 
-      - name: Cache composer dependencies
-        uses: actions/cache@v2
+      - name: Install dependencies
+        uses: ramsey/composer-install@v1
         with:
-          path: vendor
-          key: composer-${{ hashFiles('composer.lock') }}
-
-      - name: Run composer install
-        run: composer install -n --prefer-dist
+          composer-options: --optimize-autoloader
+          dependency-versions: ${{ matrix.stability }}
 
       - name: Run psalm
         run: ./vendor/bin/psalm --output-format=github

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,8 +9,8 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.0]
-        stability: [prefer-lowest, prefer-stable]
+        php: [8.1]
+        stability: [lowest, highest]
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
@@ -22,7 +22,6 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
           coverage: none
 
       - name: Setup problem matchers
@@ -31,7 +30,10 @@ jobs:
           echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
       - name: Install dependencies
-        run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+        uses: ramsey/composer-install@v1
+        with:
+          composer-options: --optimize-autoloader
+          dependency-versions: ${{ matrix.stability }}
 
       - name: Execute tests
         run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.17",
         "phpunit/phpunit": "^9.5",
-        "spatie/ray": "^1.10",
         "vimeo/psalm": "^4.3"
     },
     "autoload": {


### PR DESCRIPTION
This PR refactored the GitHub actions with the goal to make them work properly again
For this all extensions have been removed from the php setup as they are not needed, removing with them all php 8.1 incompatibilities.
The used php version has also been upgraded to php 8.1 as this is the minimum version for this package.
The `spatie/ray` package has been removed as it requires `ramsey/uuid` which is not yet compatible with php 8.1 and makes static analysis with psalm fail.

