### PR TITLE
Use correct scope to assign inherited properties

### DIFF
--- a/src/Cloneable.php
+++ b/src/Cloneable.php
@@ -8,12 +8,19 @@ trait Cloneable
 {
     public function with(...$values): static
     {
-        $clone = (new ReflectionClass(static::class))->newInstanceWithoutConstructor();
+        $refClass = new ReflectionClass(static::class);
+        $clone = $refClass->newInstanceWithoutConstructor();
 
         foreach (get_object_vars($this) as $objectField => $objectValue) {
             $objectValue = array_key_exists($objectField, $values) ? $values[$objectField] : $objectValue;
 
-            $clone->$objectField = $objectValue;
+            $declarationScope = $refClass->getProperty($objectField)->getDeclaringClass()->getName();
+            if ($declarationScope === self::class) {
+                $clone->$objectField = $objectValue;
+            } else {
+                (fn () => $this->$objectField = $objectValue)
+                    ->bindTo($clone, $declarationScope)();
+            }
         }
 
         return $clone;

--- a/tests/InheritedCloneableTest.php
+++ b/tests/InheritedCloneableTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Spatie\Cloneable\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Spatie\Cloneable\Cloneable;
+
+class InheritedCloneableTest extends TestCase
+{
+    /** @test */
+    public function it_can_clone_inherited_properties()
+    {
+        $object1 = new InheritedCloneable(a: 'foo', b: 'bar');
+        $object2 = $object1->with(b: 'baz');
+
+        $this->assertEquals('foo', $object2->a);
+        $this->assertEquals('baz', $object2->b);
+    }
+}
+
+class InheritedCloneableBase
+{
+    use Cloneable;
+
+    public function __construct(
+        public readonly string $a,
+    ) {
+    }
+}
+
+class InheritedCloneable extends InheritedCloneableBase
+{
+    public function __construct(
+        string $a,
+        public readonly string $b
+    )
+    {
+        parent::__construct($a);
+    }
+
+}


### PR DESCRIPTION
Trying to assign readonly-property inherited from parent class will throw error "Cannot initialize readonly property A::$foo from scope B".
Suggested workaround is to create a closure with that assignment and call it in a scope of the class where that property was declared (found in `ReflectionProperty::getDeclaringClass()`).