### PR TITLE
Allow setting of uninitalised properties

### DIFF
--- a/tests/CloneableTest.php
+++ b/tests/CloneableTest.php
@@ -27,11 +27,36 @@ class CloneableTest extends TestCase
 
         $this->assertNull($postB->nullable);
     }
+
+    /** @test */
+    public function it_can_set_uninitialised_values()
+    {
+        $postA = new Post('a');
+
+        $postB = $postA->with(uninitialised: 'Now initialised');
+
+        $this->assertFalse(isset($postA->uninitialised));
+        $this->assertEquals('Now initialised', $postB->uninitialised);
+    }
+
+    /** @test */
+    public function it_does_not_modify_static_properties()
+    {
+        $postA = new Post('a');
+        Post::$counter = 42;
+
+        $postA->with(title: 'b');
+
+        $this->assertEquals(42, Post::$counter);
+    }
 }
 
 class Post
 {
     use Cloneable;
+
+    public readonly string $uninitialised;
+    public static int $counter = 0;
 
     public function __construct(
         public readonly string $title,


### PR DESCRIPTION
The get_object_vars() method only returns initialised properties. It is perfectly legitimate to instantiate an object without setting all properties initially and to then update in a subsequent call.

Sadly this is not possible using get_object_vars() so I have modified the approach to extend upon the existing Reflection.